### PR TITLE
Adding Approval Status

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -28,6 +28,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const botSuffix = "[bot]"
+
 type Rule struct {
 	Name        string               `yaml:"name"`
 	Description string               `yaml:"description"`
@@ -42,6 +44,7 @@ type Options struct {
 	AllowNonAuthorContributor bool `yaml:"allow_non_author_contributor"`
 	InvalidateOnPush          bool `yaml:"invalidate_on_push"`
 
+	IgnoreBotComments    bool          `yaml:"ignore_bot_comments"`
 	IgnoreEditedComments bool          `yaml:"ignore_edited_comments"`
 	IgnoreUpdateMerges   bool          `yaml:"ignore_update_merges"`
 	IgnoreCommitsBy      common.Actors `yaml:"ignore_commits_by"`
@@ -273,9 +276,18 @@ func (r *Rule) FilteredCandidates(ctx context.Context, prctx pull.Context) ([]*c
 		}
 	}
 
+	var botDismissals []*common.Dismissal
+	if r.Options.IgnoreBotComments {
+		candidates, botDismissals, err = r.filterBotCandidates(ctx, prctx, candidates)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	var dismissals []*common.Dismissal
 	dismissals = append(dismissals, editDismissals...)
 	dismissals = append(dismissals, pushDismissals...)
+	dismissals = append(dismissals, botDismissals...)
 
 	return candidates, dismissals, nil
 }
@@ -339,6 +351,30 @@ func (r *Rule) filterInvalidCandidates(ctx context.Context, prctx pull.Context, 
 		"discarded %d candidates invalidated by push of %s on or before %s",
 		len(dismissed), sha, lastPushedAt.Format(time.RFC3339),
 	)
+
+	return allowed, dismissed, nil
+}
+
+func (r *Rule) filterBotCandidates(ctx context.Context, prctx pull.Context, candidates []*common.Candidate) ([]*common.Candidate, []*common.Dismissal, error) {
+	var allowed []*common.Candidate
+	var dismissed []*common.Dismissal
+
+	for _, c := range candidates {
+		if strings.HasSuffix(c.User, botSuffix) {
+			dismissed = append(dismissed, &common.Dismissal{
+				Candidate: c,
+				Reason:    fmt.Sprintf("Ignored comment by bot: %s", c.User),
+			})
+
+			continue
+		}
+
+		allowed = append(allowed, c)
+	}
+
+	if len(dismissed) > 0 {
+		zerolog.Ctx(ctx).Debug().Msgf("discarded %d candidates due to being comments by bots", len(dismissed))
+	}
 
 	return allowed, dismissed, nil
 }

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -86,6 +86,12 @@ func TestIsApproved(t *testing.T) {
 					Author:       "comment-editor",
 					Body:         "LGTM :+1: :shipit:",
 				},
+				{
+					CreatedAt:    now.Add(80 * time.Second),
+					LastEditedAt: time.Time{},
+					Author:       "bot-user[bot]",
+					Body:         "I am a bot :+1:",
+				},
 			},
 			ReviewsValue: []*pull.Review{
 				{
@@ -179,7 +185,7 @@ func TestIsApproved(t *testing.T) {
 				Count: 1,
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 	})
 
 	t.Run("authorCannotApprove", func(t *testing.T) {
@@ -317,7 +323,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 	})
 
 	t.Run("specificOrgApproves", func(t *testing.T) {
@@ -340,7 +346,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 	})
 
 	t.Run("specificOrgsOrUserApproves", func(t *testing.T) {
@@ -382,7 +388,7 @@ func TestIsApproved(t *testing.T) {
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r.Options.InvalidateOnPush = true
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
 	})
 
 	t.Run("invalidateReviewOnPush", func(t *testing.T) {
@@ -441,7 +447,7 @@ func TestIsApproved(t *testing.T) {
 				InvalidateOnPush: true,
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
 
 		r.Options.IgnoreUpdateMerges = true
 		assertApproved(t, prctx, r, "Approved by comment-approver")
@@ -473,7 +479,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 9 approvals from disqualified users")
 
 		r.Options.IgnoreUpdateMerges = true
 		assertApproved(t, prctx, r, "Approved by merge-committer")
@@ -496,7 +502,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 
 		r.Options.IgnoreCommitsBy = common.Actors{
 			Users: []string{"comment-approver"},
@@ -520,7 +526,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 	})
 
 	t.Run("ignoreCommitsInvalidateOnPush", func(t *testing.T) {
@@ -592,7 +598,7 @@ func TestIsApproved(t *testing.T) {
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r.Options.InvalidateOnPush = true
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
 
 		r.Options.IgnoreCommitsBy = common.Actors{
 			Users: []string{"mhaypenny"},
@@ -616,7 +622,7 @@ func TestIsApproved(t *testing.T) {
 
 		r.Options.IgnoreEditedComments = true
 
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
 	})
 
 	t.Run("ignoreEditedComments", func(t *testing.T) {
@@ -635,7 +641,7 @@ func TestIsApproved(t *testing.T) {
 
 		r.Options.IgnoreEditedComments = true
 
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
 	})
 
 	t.Run("ignoreEditedCommentsWithBodyPattern", func(t *testing.T) {
@@ -662,7 +668,43 @@ func TestIsApproved(t *testing.T) {
 
 		r.Options.IgnoreEditedComments = true
 
-		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
+	})
+
+	t.Run("allowBotComments", func(t *testing.T) {
+		prctx := basePullContext()
+
+		r := &Rule{
+			Requires: common.Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Users: []string{"bot-user[bot]"},
+				},
+			},
+			Options: Options{
+				IgnoreBotComments: false,
+			},
+		}
+
+		assertApproved(t, prctx, r, "Approved by bot-user[bot]")
+	})
+
+	t.Run("ignoreBotComments", func(t *testing.T) {
+		prctx := basePullContext()
+
+		r := &Rule{
+			Requires: common.Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Users: []string{"bot-user[bot]"},
+				},
+			},
+			Options: Options{
+				IgnoreBotComments: true,
+			},
+		}
+
+		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
 	})
 }
 

--- a/server/handler/approval_status.go
+++ b/server/handler/approval_status.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ApprovalStatus evaluates the approval status for a pull request based on it's current state. Unlike the standard
-// GitHub event handlers, the the status in this case is returned and not written back to the pull request.
+// GitHub event handlers, the status in this case is returned and not written back to the pull request.
 type ApprovalStatus struct {
 	Base
 }

--- a/server/handler/approval_status.go
+++ b/server/handler/approval_status.go
@@ -79,13 +79,16 @@ func (h *ApprovalStatus) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if ?ignorebots=true is included in the query, approval comments from bots, such as policy-bot be ignored
+	ignoreCommentsFromBots := r.URL.Query().Has(ignoreBotsParam) && r.URL.Query().Get(ignoreBotsParam) == "true"
+
 	ctx, logger = h.PreparePRContext(ctx, installation.ID, pr)
 	result, err := h.getApprovalResult(ctx, installation, pull.Locator{
 		Owner:  owner,
 		Repo:   repo,
 		Number: number,
 		Value:  pr,
-	}, r.URL.Query().Has(ignoreBotsParam))
+	}, ignoreCommentsFromBots)
 
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to get approval result for pull request")

--- a/server/handler/approval_status.go
+++ b/server/handler/approval_status.go
@@ -27,8 +27,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// ApprovalStatus evaluates the current approval status for a pull request based on it's current state. Unlike the standard
-// GitHub event handlers however, the the status in this case is returned and not written back to the pull request.
+// ApprovalStatus evaluates the approval status for a pull request based on it's current state. Unlike the standard
+// GitHub event handlers, the the status in this case is returned and not written back to the pull request.
 type ApprovalStatus struct {
 	Base
 }

--- a/server/handler/approval_status.go
+++ b/server/handler/approval_status.go
@@ -100,12 +100,12 @@ func (h *ApprovalStatus) getApprovalResult(ctx context.Context, installation git
 	switch {
 	case err != nil:
 		return nil, errors.Wrap(err, "failed to generate eval context")
-	case evalCtx.Config.Config == nil:
-		return nil, errors.Wrap(err, "no policy file found in repo")
 	case evalCtx.Config.LoadError != nil:
 		return nil, errors.Wrap(evalCtx.Config.LoadError, "failed to load policy file")
 	case evalCtx.Config.ParseError != nil:
 		return nil, errors.Wrap(evalCtx.Config.ParseError, "failed to parse policy")
+	case evalCtx.Config.Config == nil:
+		return nil, errors.New("no policy file found in repo")
 	}
 
 	evaluator, err := policy.ParsePolicy(evalCtx.Config.Config)

--- a/server/handler/dry_run.go
+++ b/server/handler/dry_run.go
@@ -32,8 +32,8 @@ const (
 	LogKeyDryRun = "dry_run"
 )
 
-// DryRun evaluates the current approval status for a pull request based on it's current state, however unlike the
-// standard GitHub event handlers, the the status in this case is returned and not written back to the pull request.
+// DryRun evaluates the current approval status for a pull request based on it's current state. Unlike the standard GitHub
+// event handlers however, the the status in this case is returned and not written back to the pull request.
 type DryRun struct {
 	Base
 }

--- a/server/handler/dry_run.go
+++ b/server/handler/dry_run.go
@@ -1,0 +1,129 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/go-github/v58/github"
+	"github.com/palantir/go-baseapp/baseapp"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/rs/zerolog"
+)
+
+const (
+	LogKeyDryRun = "dry_run"
+)
+
+// DryRun performs an evaluation of of a specific pull request, similar to if the evaluation how been triggered by a
+// GitHub event. However instead of writing the result as a status back to the pr, it returns a response indicating
+// what the status would be if the pr was triggered from a GitHub event as normal.
+type DryRun struct {
+	Base
+}
+
+type DryRunResponse struct {
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+func (h *DryRun) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := zerolog.Ctx(ctx)
+	var response DryRunResponse
+
+	owner, repo, number, ok := parsePullParams(r)
+	if !ok {
+		logger.Error().Msg("failed to parse pull request parameters from request")
+		baseapp.WriteJSON(w, http.StatusBadRequest, &response)
+		return
+	}
+
+	installation, err := h.Installations.GetByOwner(ctx, owner)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get installation for org")
+		baseapp.WriteJSON(w, http.StatusNotFound, &response)
+		return
+	}
+
+	client, err := h.ClientCreator.NewInstallationClient(installation.ID)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to create github client")
+		baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		return
+	}
+
+	pr, _, err := client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get pr")
+		if isNotFound(err) {
+			baseapp.WriteJSON(w, http.StatusNotFound, &response)
+		} else {
+			baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		}
+
+		return
+	}
+
+	ctx, logger = h.prepareDryRunContext(ctx, installation.ID, pr)
+	evalCtx, err := h.NewEvalContext(ctx, installation.ID, pull.Locator{
+		Owner:  owner,
+		Repo:   repo,
+		Number: number,
+		Value:  pr,
+	})
+
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to generate eval context")
+		baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		return
+	}
+
+	evaluator, err := evalCtx.ParseConfig(ctx, common.TriggerAll)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get evaluator")
+		baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		return
+	}
+
+	if evaluator == nil {
+		logger.Error().Msg("evaluator was nil")
+		baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		return
+	}
+
+	result := evaluator.Evaluate(ctx, evalCtx.PullContext)
+	if result.Error != nil {
+		logger.Error().Err(result.Error).Msgf("error evaluating policy in %s: %s", evalCtx.Config.Source, evalCtx.Config.Path)
+		baseapp.WriteJSON(w, http.StatusInternalServerError, &response)
+		return
+	}
+
+	response.Status = result.Status.String()
+	response.Description = result.StatusDescription
+	baseapp.WriteJSON(w, http.StatusOK, &response)
+}
+
+func (h *DryRun) prepareDryRunContext(ctx context.Context, installationID int64, pr *github.PullRequest) (context.Context, *zerolog.Logger) {
+	ctx, logger := githubapp.PreparePRContext(ctx, installationID, pr.GetBase().GetRepo(), pr.GetNumber())
+
+	logger = logger.With().Bool(LogKeyDryRun, true).Str(LogKeyGitHubSHA, pr.GetHead().GetSHA()).Logger()
+	ctx = logger.WithContext(ctx)
+
+	return ctx, &logger
+}

--- a/server/server.go
+++ b/server/server.go
@@ -217,7 +217,7 @@ func New(c *Config) (*Server, error) {
 	// additional API routes
 	mux.Handle(pat.Get("/api/health"), handler.Health())
 	mux.Handle(pat.Put("/api/validate"), handler.Validate())
-	mux.Handle(pat.Get("/api/:owner/:repo/:number/dryrun"), &handler.DryRun{Base: basePolicyHandler})
+	mux.Handle(pat.Get("/api/:owner/:repo/:number/status"), &handler.ApprovalStatus{Base: basePolicyHandler})
 	mux.Handle(pat.Get(oauth2.DefaultRoute), oauth2.NewHandler(
 		oauth2.GetConfig(c.Github, nil),
 		oauth2.ForceTLS(forceTLS),

--- a/server/server.go
+++ b/server/server.go
@@ -217,7 +217,7 @@ func New(c *Config) (*Server, error) {
 	// additional API routes
 	mux.Handle(pat.Get("/api/health"), handler.Health())
 	mux.Handle(pat.Put("/api/validate"), handler.Validate())
-	mux.Handle(pat.Get("/api/dryrun/:owner/:repo/:number"), &handler.DryRun{Base: basePolicyHandler})
+	mux.Handle(pat.Get("/api/:owner/:repo/:number/dryrun"), &handler.DryRun{Base: basePolicyHandler})
 	mux.Handle(pat.Get(oauth2.DefaultRoute), oauth2.NewHandler(
 		oauth2.GetConfig(c.Github, nil),
 		oauth2.ForceTLS(forceTLS),

--- a/server/server.go
+++ b/server/server.go
@@ -217,6 +217,7 @@ func New(c *Config) (*Server, error) {
 	// additional API routes
 	mux.Handle(pat.Get("/api/health"), handler.Health())
 	mux.Handle(pat.Put("/api/validate"), handler.Validate())
+	mux.Handle(pat.Get("/api/dryrun/:owner/:repo/:number"), &handler.DryRun{Base: basePolicyHandler})
 	mux.Handle(pat.Get(oauth2.DefaultRoute), oauth2.NewHandler(
 		oauth2.GetConfig(c.Github, nil),
 		oauth2.ForceTLS(forceTLS),


### PR DESCRIPTION
Adds a new endpoint: `/api/:owner/:repo/:number/status` which can be used to return the current approval status of a pull request without having the result written back to the GitHub status check of the pr.

```json
{"status":"approved","description":"All rules are approved"}
```

An `ignorebots` query param can also be included to instruct policy-bot to ignore all bot comments (comments from itself for instance) when evaluating if a pull request is approved.