### PR TITLE
Example add support for branch simulation

### DIFF
--- a/pull/simulated/context.go
+++ b/pull/simulated/context.go
@@ -60,3 +60,12 @@ func (c *Context) Reviews() ([]*pull.Review, error) {
 
 	return reviews, nil
 }
+
+func (c *Context) Branches() (string, string) {
+	base, head := c.Context.Branches()
+	if c.options.BaseBranch != "" {
+		return c.options.BaseBranch, head
+	}
+
+	return base, head
+}

--- a/pull/simulated/context_test.go
+++ b/pull/simulated/context_test.go
@@ -161,6 +161,43 @@ func TestReviews(t *testing.T) {
 	}
 }
 
+func TestBranches(t *testing.T) {
+	tests := map[string]struct {
+		Base         string
+		Head         string
+		Options      Options
+		ExpectedBase string
+		ExpectedHead string
+	}{
+		"use default base branch": {
+			Base:         "develop",
+			Head:         "aa/feature1",
+			ExpectedBase: "develop",
+			ExpectedHead: "aa/feature1",
+		},
+		"use simulated base branch": {
+			Base:         "develop",
+			Head:         "aa/feature1",
+			ExpectedBase: "simulated-develop",
+			ExpectedHead: "aa/feature1",
+			Options: Options{
+				BaseBranch: "simulated-develop",
+			},
+		},
+	}
+
+	for message, test := range tests {
+		context := Context{
+			Context: &testPullContext{base: test.Base, head: test.Head},
+			options: test.Options,
+		}
+
+		base, head := context.Branches()
+		assert.Equal(t, test.ExpectedBase, base, message)
+		assert.Equal(t, test.ExpectedHead, head, message)
+	}
+}
+
 func commentAuthors(comments []*pull.Comment) []string {
 	var authors []string
 	for _, c := range comments {
@@ -183,6 +220,8 @@ type testPullContext struct {
 	pull.Context
 	comments []*pull.Comment
 	reviews  []*pull.Review
+	base     string
+	head     string
 }
 
 func (c *testPullContext) Comments() ([]*pull.Comment, error) {
@@ -191,4 +230,8 @@ func (c *testPullContext) Comments() ([]*pull.Comment, error) {
 
 func (c *testPullContext) Reviews() ([]*pull.Review, error) {
 	return c.reviews, nil
+}
+
+func (c *testPullContext) Branches() (string, string) {
+	return c.base, c.head
 }

--- a/pull/simulated/options.go
+++ b/pull/simulated/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	Ignore             string
 	AddApprovalComment string
 	AddApprovalReview  string
+	BaseBranch         string
 }
 
 func (o *Options) filterIgnoredComments(comments []*pull.Comment) []*pull.Comment {

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -30,6 +30,7 @@ const (
 	ignoreParam  = "ignore"
 	commentParam = "comment"
 	reviewParam  = "review"
+	branchParam  = "branch"
 )
 
 // Simulate provides a baseline for handlers to perform simulated pull request evaluations and
@@ -113,6 +114,10 @@ func getSimulatedOptions(r *http.Request) simulated.Options {
 
 	if r.URL.Query().Has(reviewParam) {
 		options.AddApprovalReview = r.URL.Query().Get(reviewParam)
+	}
+
+	if r.URL.Query().Has(branchParam) {
+		options.BaseBranch = r.URL.Query().Get(branchParam)
 	}
 
 	return options


### PR DESCRIPTION
Example of how https://github.com/atatkin/policy-bot/pull/2 might be extended in the future to include support for simulating a different `base branch` when evaluating the policy for a pr.